### PR TITLE
feat: replace jackson-module-jsonSchema with victools jsonschema-generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ dependencies {
     // The generated IOF v2/3 files
     implementation sourceSets.generated.output
 
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: '2.21.2'
+    implementation 'com.github.victools:jsonschema-generator:4.38.0'
+    implementation 'com.github.victools:jsonschema-module-jackson:4.38.0'
 
     testImplementation platform("org.junit:junit-bom:6.0.3")
     testImplementation "org.junit.jupiter:junit-jupiter"

--- a/src/main/kotlin/iofXml/JsonMarshal.kt
+++ b/src/main/kotlin/iofXml/JsonMarshal.kt
@@ -103,13 +103,13 @@ internal fun iofJsonToXml(json: String, iofVersion: String = "v3"): String {
  * @sample iofXml.JsonMarshalKtTest.marshalIofObjectToJson
  */
 fun marshalIofObjectToJson(obj: Any, prettyPrint: Boolean = true): String {
-    val mapper = ObjectMapper()
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL) // Else all fields not set will be 'null'
-    if (prettyPrint) {
-        mapper.enable(SerializationFeature.INDENT_OUTPUT)
+    val mapper = ObjectMapper().apply {
+        // Omit null fields so only explicitly set values appear in output
+        configOverride(Any::class.java).setInclude(
+            JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL)
+        )
+        if (prettyPrint) enable(SerializationFeature.INDENT_OUTPUT)
     }
-
-    //mapper.enable(SerializationFeature.WRAP_ROOT_VALUE) // Problem: root will be UpperCamelCase (need lowerCamelCase)
     val className = nameFromJavaClass(obj.javaClass)
     val objectWithRoot = mapOf(className to obj)
 

--- a/src/main/kotlin/iofXml/JsonSchemaGenerator.kt
+++ b/src/main/kotlin/iofXml/JsonSchemaGenerator.kt
@@ -1,0 +1,57 @@
+package iofXml
+
+import com.github.victools.jsonschema.generator.OptionPreset
+import com.github.victools.jsonschema.generator.SchemaGenerator
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
+import com.github.victools.jsonschema.generator.SchemaVersion
+import com.github.victools.jsonschema.module.jackson.JacksonModule
+
+private fun buildSchemaGenerator(schemaVersion: SchemaVersion): SchemaGenerator {
+    val jacksonModule = JacksonModule()
+    val configBuilder = SchemaGeneratorConfigBuilder(schemaVersion, OptionPreset.PLAIN_JSON)
+        .with(jacksonModule)
+    return SchemaGenerator(configBuilder.build())
+}
+
+/**
+ * Generate a JSON Schema (Draft 2019-09) for an IOF V3 top-level class.
+ *
+ * @param clazz the IOF V3 class to generate schema for, e.g. `iofXml.v3.StartList::class.java`
+ * @param schemaVersion the JSON Schema draft version to generate (default: 2019-09)
+ * @return JSON Schema as a string
+ * @sample iofXml.JsonSchemaGeneratorKtTest.generateSchemaForStartList
+ */
+fun generateJsonSchemaForClass(
+    clazz: Class<*>,
+    schemaVersion: SchemaVersion = SchemaVersion.DRAFT_2019_09
+): String = buildSchemaGenerator(schemaVersion).generateSchema(clazz).toPrettyString()
+
+/**
+ * Generate JSON Schemas (Draft 2019-09) for all supported IOF V3 top-level classes.
+ *
+ * @param schemaVersion the JSON Schema draft version to generate (default: 2019-09)
+ * @return map of class name to JSON Schema string
+ */
+fun generateJsonSchemasForIofV3(
+    schemaVersion: SchemaVersion = SchemaVersion.DRAFT_2019_09
+): Map<String, String> {
+    val generator = buildSchemaGenerator(schemaVersion)
+    return classesV3.associate { clazz ->
+        nameFromJavaClass(clazz) to generator.generateSchema(clazz).toPrettyString()
+    }
+}
+
+/**
+ * Generate JSON Schemas (Draft 2019-09) for all supported IOF V2 top-level classes.
+ *
+ * @param schemaVersion the JSON Schema draft version to generate (default: 2019-09)
+ * @return map of class name to JSON Schema string
+ */
+fun generateJsonSchemasForIofV2(
+    schemaVersion: SchemaVersion = SchemaVersion.DRAFT_2019_09
+): Map<String, String> {
+    val generator = buildSchemaGenerator(schemaVersion)
+    return classesV2.associate { clazz ->
+        nameFromJavaClass(clazz) to generator.generateSchema(clazz).toPrettyString()
+    }
+}

--- a/src/main/kotlin/iofXml/Main.kt
+++ b/src/main/kotlin/iofXml/Main.kt
@@ -72,7 +72,7 @@ val classesV3 = listOf(
 /**
  * List of all names for all main classes of IOF V3 XSD specification, generated from [classesV3][classesV3].
  */
-val classNamesV3 = classesV3.map { nameFromJavaClass(it.javaClass) }
+val classNamesV3 = classesV3.map { nameFromJavaClass(it) }
 
 /**
  * List of all main types / classes of IOF V2 XSD specification. Only these
@@ -97,4 +97,4 @@ val classesV2 = listOf(
 /**
  * List of all names for all main classes of IOF V2 XSD specification, generated from [classesV2][classesV2].
  */
-val classNamesV2 = classesV2.map { nameFromJavaClass(it.javaClass) }
+val classNamesV2 = classesV2.map { nameFromJavaClass(it) }

--- a/src/main/kotlin/iofXml/V2Unmarshallers.kt
+++ b/src/main/kotlin/iofXml/V2Unmarshallers.kt
@@ -1,7 +1,6 @@
 package iofXml
 
 import java.io.StringReader
-import java.lang.Class
 import jakarta.xml.bind.JAXBContext
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.transform.sax.SAXSource
@@ -19,29 +18,17 @@ fun unmarshalGenericIofV2(xml: String): Triple<Any, String, Class<*>> {
     val className = getMainElementName(xml) ?: ""
     val xmlClean = removeUTF8BOM(xml, className)
     val actualClass = Class.forName("iofXml.v2.$className")
-
     val jaxbContext = JAXBContext.newInstance(actualClass)
-
     val unmarshall = jaxbContext.createUnmarshaller()
 
-    val validateXml = false
-    return if (validateXml) {
-        /*
-            This does not work, because it tries to load ethe IOFdata.dtd file, which I can't make work.
-         */
-        val reader = StringReader(xmlClean)
-        Triple(unmarshall.unmarshal(reader), className, actualClass)
-    } else {
-        // Credit: https://stackoverflow.com/a/64931583/5550386
-        val spf = SAXParserFactory.newInstance()
-        // Do not validate DTD
-        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        val xmlSource = SAXSource(
-            spf.newSAXParser().xmlReader,
-            InputSource(StringReader(xmlClean))
-        )
-        Triple(unmarshall.unmarshal(xmlSource), className, actualClass)
-    }
+    // Credit: https://stackoverflow.com/a/64931583/5550386
+    val spf = SAXParserFactory.newInstance()
+    spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    val xmlSource = SAXSource(
+        spf.newSAXParser().xmlReader,
+        InputSource(StringReader(xmlClean))
+    )
+    return Triple(unmarshall.unmarshal(xmlSource), className, actualClass)
 }
 
 /**
@@ -55,30 +42,21 @@ private fun unmarshalV2Xml(className: String, dirtyXml: String): Any {
     val xml = removeUTF8BOM(dirtyXml, mainElementName)
 
     if (mainElementName != className) {
-        println("ERROR V2: mainElementName=$mainElementName is not equal to className=$className")
+        throw IllegalArgumentException("Expected IOF V2 element '$className' but found '$mainElementName'")
     }
 
     val actualClass = Class.forName("iofXml.v2.$className")
-
     val jaxbContext = JAXBContext.newInstance(actualClass)
-
-    val turnOfDtdValidation = true
     val unmarshall = jaxbContext.createUnmarshaller()
 
-    return if (turnOfDtdValidation) {
-        // Credit: https://stackoverflow.com/a/64931583/5550386
-        val spf = SAXParserFactory.newInstance()
-        // Do not validate DTD
-        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        val xmlSource = SAXSource(
-            spf.newSAXParser().xmlReader,
-            InputSource(StringReader(xml))
-        )
-        unmarshall.unmarshal(xmlSource)
-    } else {
-        val reader = StringReader(xml)
-        unmarshall.unmarshal(reader)
-    }
+    // Credit: https://stackoverflow.com/a/64931583/5550386
+    val spf = SAXParserFactory.newInstance()
+    spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    val xmlSource = SAXSource(
+        spf.newSAXParser().xmlReader,
+        InputSource(StringReader(xml))
+    )
+    return unmarshall.unmarshal(xmlSource)
 }
 
 /** IOF V2: Deserialize PersonList XML to an object of type PersonList */

--- a/src/main/kotlin/iofXml/V3Unmarshallers.kt
+++ b/src/main/kotlin/iofXml/V3Unmarshallers.kt
@@ -1,7 +1,6 @@
 package iofXml
 
 import java.io.StringReader
-import java.lang.Class
 import java.net.URL
 import jakarta.xml.bind.JAXBContext
 import javax.xml.XMLConstants
@@ -45,7 +44,7 @@ private fun unmarshalV3Xml(className: String, dirtyXml: String, validateXml: Boo
     val mainElementName = getMainElementName(dirtyXml) ?: ""
     val xml = removeUTF8BOM(dirtyXml, mainElementName)
     if (mainElementName != className) {
-        println("ERROR V3: mainElementName=$mainElementName is not equal to className=$className")
+        throw IllegalArgumentException("Expected IOF V3 element '$className' but found '$mainElementName'")
     }
 
     val actualClass = Class.forName("iofXml.v3.$className")

--- a/src/test/kotlin/iofXml/JsonSchemaGeneratorKtTest.kt
+++ b/src/test/kotlin/iofXml/JsonSchemaGeneratorKtTest.kt
@@ -1,0 +1,48 @@
+package iofXml
+
+import com.github.victools.jsonschema.generator.SchemaVersion
+import iofXml.v3.StartList
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JsonSchemaGeneratorKtTest {
+
+    @Test
+    fun generateSchemaForStartList() {
+        val schema = generateJsonSchemaForClass(StartList::class.java)
+        assertTrue(schema.contains("\"type\""))
+        assertTrue(schema.contains("\"properties\""))
+    }
+
+    @Test
+    fun generateSchemaUsesDraft201909ByDefault() {
+        val schema = generateJsonSchemaForClass(StartList::class.java)
+        assertTrue(schema.contains("https://json-schema.org/draft/2019-09/schema"))
+    }
+
+    @Test
+    fun generateSchemaWithDraft7() {
+        val schema = generateJsonSchemaForClass(StartList::class.java, SchemaVersion.DRAFT_7)
+        assertTrue(schema.contains("http://json-schema.org/draft-07/schema"))
+    }
+
+    @Test
+    fun generateSchemasForAllIofV3Classes() {
+        val schemas = generateJsonSchemasForIofV3()
+        assertTrue(schemas.isNotEmpty())
+        assertTrue(schemas.containsKey("startList"))
+        assertTrue(schemas.containsKey("classList"))
+        schemas.values.forEach { schema ->
+            assertTrue(schema.contains("\"type\""))
+        }
+    }
+
+    @Test
+    fun generateSchemasForAllIofV2Classes() {
+        val schemas = generateJsonSchemasForIofV2()
+        assertTrue(schemas.isNotEmpty())
+        schemas.values.forEach { schema ->
+            assertTrue(schema.contains("\"type\""))
+        }
+    }
+}


### PR DESCRIPTION
jackson-module-jsonSchema is officially deprecated (supports only Draft 3). mbknor-jackson-jsonSchema (suggested in #14) has been abandoned since 2021.

victools/jsonschema-generator is the actively maintained state-of-the-art alternative, supporting Draft 6, 7, 2019-09, and 2020-12.

Adds generateJsonSchemaForClass, generateJsonSchemasForIofV3, and generateJsonSchemasForIofV2 utility functions.

Closes #14