### PR TITLE
chore: code quality improvements

### DIFF
--- a/src/main/kotlin/iofXml/JsonMarshal.kt
+++ b/src/main/kotlin/iofXml/JsonMarshal.kt
@@ -103,13 +103,13 @@ internal fun iofJsonToXml(json: String, iofVersion: String = "v3"): String {
  * @sample iofXml.JsonMarshalKtTest.marshalIofObjectToJson
  */
 fun marshalIofObjectToJson(obj: Any, prettyPrint: Boolean = true): String {
-    val mapper = ObjectMapper()
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL) // Else all fields not set will be 'null'
-    if (prettyPrint) {
-        mapper.enable(SerializationFeature.INDENT_OUTPUT)
+    val mapper = ObjectMapper().apply {
+        // Omit null fields so only explicitly set values appear in output
+        configOverride(Any::class.java).setInclude(
+            JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL)
+        )
+        if (prettyPrint) enable(SerializationFeature.INDENT_OUTPUT)
     }
-
-    //mapper.enable(SerializationFeature.WRAP_ROOT_VALUE) // Problem: root will be UpperCamelCase (need lowerCamelCase)
     val className = nameFromJavaClass(obj.javaClass)
     val objectWithRoot = mapOf(className to obj)
 

--- a/src/main/kotlin/iofXml/Main.kt
+++ b/src/main/kotlin/iofXml/Main.kt
@@ -72,7 +72,7 @@ val classesV3 = listOf(
 /**
  * List of all names for all main classes of IOF V3 XSD specification, generated from [classesV3][classesV3].
  */
-val classNamesV3 = classesV3.map { nameFromJavaClass(it.javaClass) }
+val classNamesV3 = classesV3.map { nameFromJavaClass(it) }
 
 /**
  * List of all main types / classes of IOF V2 XSD specification. Only these
@@ -97,4 +97,4 @@ val classesV2 = listOf(
 /**
  * List of all names for all main classes of IOF V2 XSD specification, generated from [classesV2][classesV2].
  */
-val classNamesV2 = classesV2.map { nameFromJavaClass(it.javaClass) }
+val classNamesV2 = classesV2.map { nameFromJavaClass(it) }

--- a/src/main/kotlin/iofXml/V2Unmarshallers.kt
+++ b/src/main/kotlin/iofXml/V2Unmarshallers.kt
@@ -1,7 +1,6 @@
 package iofXml
 
 import java.io.StringReader
-import java.lang.Class
 import jakarta.xml.bind.JAXBContext
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.transform.sax.SAXSource
@@ -19,29 +18,17 @@ fun unmarshalGenericIofV2(xml: String): Triple<Any, String, Class<*>> {
     val className = getMainElementName(xml) ?: ""
     val xmlClean = removeUTF8BOM(xml, className)
     val actualClass = Class.forName("iofXml.v2.$className")
-
     val jaxbContext = JAXBContext.newInstance(actualClass)
-
     val unmarshall = jaxbContext.createUnmarshaller()
 
-    val validateXml = false
-    return if (validateXml) {
-        /*
-            This does not work, because it tries to load ethe IOFdata.dtd file, which I can't make work.
-         */
-        val reader = StringReader(xmlClean)
-        Triple(unmarshall.unmarshal(reader), className, actualClass)
-    } else {
-        // Credit: https://stackoverflow.com/a/64931583/5550386
-        val spf = SAXParserFactory.newInstance()
-        // Do not validate DTD
-        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        val xmlSource = SAXSource(
-            spf.newSAXParser().xmlReader,
-            InputSource(StringReader(xmlClean))
-        )
-        Triple(unmarshall.unmarshal(xmlSource), className, actualClass)
-    }
+    // Credit: https://stackoverflow.com/a/64931583/5550386
+    val spf = SAXParserFactory.newInstance()
+    spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    val xmlSource = SAXSource(
+        spf.newSAXParser().xmlReader,
+        InputSource(StringReader(xmlClean))
+    )
+    return Triple(unmarshall.unmarshal(xmlSource), className, actualClass)
 }
 
 /**
@@ -55,30 +42,21 @@ private fun unmarshalV2Xml(className: String, dirtyXml: String): Any {
     val xml = removeUTF8BOM(dirtyXml, mainElementName)
 
     if (mainElementName != className) {
-        println("ERROR V2: mainElementName=$mainElementName is not equal to className=$className")
+        throw IllegalArgumentException("Expected IOF V2 element '$className' but found '$mainElementName'")
     }
 
     val actualClass = Class.forName("iofXml.v2.$className")
-
     val jaxbContext = JAXBContext.newInstance(actualClass)
-
-    val turnOfDtdValidation = true
     val unmarshall = jaxbContext.createUnmarshaller()
 
-    return if (turnOfDtdValidation) {
-        // Credit: https://stackoverflow.com/a/64931583/5550386
-        val spf = SAXParserFactory.newInstance()
-        // Do not validate DTD
-        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        val xmlSource = SAXSource(
-            spf.newSAXParser().xmlReader,
-            InputSource(StringReader(xml))
-        )
-        unmarshall.unmarshal(xmlSource)
-    } else {
-        val reader = StringReader(xml)
-        unmarshall.unmarshal(reader)
-    }
+    // Credit: https://stackoverflow.com/a/64931583/5550386
+    val spf = SAXParserFactory.newInstance()
+    spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    val xmlSource = SAXSource(
+        spf.newSAXParser().xmlReader,
+        InputSource(StringReader(xml))
+    )
+    return unmarshall.unmarshal(xmlSource)
 }
 
 /** IOF V2: Deserialize PersonList XML to an object of type PersonList */

--- a/src/main/kotlin/iofXml/V3Unmarshallers.kt
+++ b/src/main/kotlin/iofXml/V3Unmarshallers.kt
@@ -1,7 +1,6 @@
 package iofXml
 
 import java.io.StringReader
-import java.lang.Class
 import java.net.URL
 import jakarta.xml.bind.JAXBContext
 import javax.xml.XMLConstants
@@ -45,7 +44,7 @@ private fun unmarshalV3Xml(className: String, dirtyXml: String, validateXml: Boo
     val mainElementName = getMainElementName(dirtyXml) ?: ""
     val xml = removeUTF8BOM(dirtyXml, mainElementName)
     if (mainElementName != className) {
-        println("ERROR V3: mainElementName=$mainElementName is not equal to className=$className")
+        throw IllegalArgumentException("Expected IOF V3 element '$className' but found '$mainElementName'")
     }
 
     val actualClass = Class.forName("iofXml.v3.$className")


### PR DESCRIPTION
- Fix bug in classNamesV3/classNamesV2: calling .javaClass on a Class<*> produced 'class' for every entry in error messages; use the Class directly instead
- Replace println error logging with IllegalArgumentException so callers get actionable feedback on mismatched element types
- Replace deprecated Jackson setSerializationInclusion with configOverride
- Remove unused java.lang.Class and java.net.URL imports